### PR TITLE
Fix Test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Test
-        run: xcodebuild test -project XCTestExample.xcodeproj/ -scheme XCTestExample -resultBundlePath TestResults -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 17"
+        run: xcodebuild test -project XCTestExample.xcodeproj/ -scheme XCTestExample -resultBundlePath TestResults.xcresult -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 17"
         
       - uses: kishikawakatsumi/xcresulttool@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Test
         run: xcodebuild test -project XCTestExample.xcodeproj/ -scheme XCTestExample -resultBundlePath TestResults.xcresult -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 17"
         
-      - uses: kishikawakatsumi/xcresulttool@v1
+      - uses: slidoapp/xcresulttool@v3
         with:
           path: TestResults.xcresult
         if: success() || failure()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Test
-        run: xcodebuild test -project XCTestExample.xcodeproj/ -scheme XCTestExample -resultBundlePath TestResults.xcresult -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 17"
+        run: xcodebuild test -project XCTestExample.xcodeproj/ -scheme XCTestExample -resultBundlePath TestResults -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 17"
         
       - uses: slidoapp/xcresulttool@v3.1.1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Test
-        run: xcodebuild test -project XCTestExample.xcodeproj/ -scheme XCTestExample -resultBundlePath TestResults -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 14"
+        run: xcodebuild test -project XCTestExample.xcodeproj/ -scheme XCTestExample -resultBundlePath TestResults -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 17"
         
       - uses: kishikawakatsumi/xcresulttool@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Test
         run: xcodebuild test -project XCTestExample.xcodeproj/ -scheme XCTestExample -resultBundlePath TestResults.xcresult -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 17"
         
-      - uses: slidoapp/xcresulttool@v3
+      - uses: slidoapp/xcresulttool@v3.1.1
         with:
           path: TestResults.xcresult
         if: success() || failure()


### PR DESCRIPTION
- [x] iPhone 14 is no longer supported. -> iPhone 17
- [x] kishikawakatsumi/xcresulttool has not been updated recently. -> https://github.com/slidoapp/xcresulttool

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change, but it may affect workflow stability if the iPhone 17 simulator or the new `xcresulttool` action behaves differently on `macOS-latest`.
> 
> **Overview**
> CI now runs iOS tests on the iPhone 17 simulator (instead of iPhone 14) and writes results to `TestResults.xcresult`.
> 
> The workflow also switches from `kishikawakatsumi/xcresulttool@v1` to `slidoapp/xcresulttool@v3` to publish the test result bundle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0769c63299aecabbd97bd92a8ca178b1fd49d45e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->